### PR TITLE
Support GHC-8.8 and regex-base-0.94

### DIFF
--- a/Text/Regex/PCRE/Wrap.hsc
+++ b/Text/Regex/PCRE/Wrap.hsc
@@ -69,6 +69,7 @@ module Text.Regex.PCRE.Wrap(
   retNoSubstring
   ) where
 
+import Control.Monad.Fail (MonadFail)
 #if defined(HAVE_PCRE_H)
 import Control.Monad(when)
 import Data.Array(Array,accumArray)
@@ -134,7 +135,7 @@ configUTF8 :: Bool
 
 (=~)  :: (RegexMaker Regex CompOption ExecOption source,RegexContext Regex source1 target)
       => source1 -> source -> target
-(=~~) :: (RegexMaker Regex CompOption ExecOption source,RegexContext Regex source1 target,Monad m)
+(=~~) :: (RegexMaker Regex CompOption ExecOption source,RegexContext Regex source1 target,MonadFail m)
       => source1 -> source -> m target
 
 #if defined(HAVE_PCRE_H)

--- a/regex-pcre-builtin.cabal
+++ b/regex-pcre-builtin.cabal
@@ -26,21 +26,23 @@ flag splitBase
   default: True
 library
   if flag(newBase)
-    Build-Depends: base >= 4 && < 5, regex-base >=0.93 && <0.94, array, containers, bytestring
+    Build-Depends: base >= 4 && < 5, regex-base >=0.93 && <0.95, array, containers, bytestring
     -- Need the next symbol for using CPP to get Data.ByteString.Base|Unsafe in
     --  ./Text/Regex/Posix/ByteString.hs and  ./Text/Regex/Posix/ByteString/Lazy.hs
     CPP-Options: "-DSPLIT_BASE=1"
     Extensions:    MultiParamTypeClasses, FunctionalDependencies, CPP, ForeignFunctionInterface, ScopedTypeVariables, GeneralizedNewtypeDeriving, FlexibleContexts, TypeSynonymInstances, FlexibleInstances
   else
     if flag(splitBase)
-      Build-Depends: base >= 3.0, regex-base >=0.93 && <0.94, array, containers, bytestring
+      Build-Depends: base >= 3.0, regex-base >=0.93 && <0.95, array, containers, bytestring
       -- Need the next symbol for using CPP to get Data.ByteString.Base|Unsafe in
       --  ./Text/Regex/Posix/ByteString.hs and  ./Text/Regex/Posix/ByteString/Lazy.hs
       CPP-Options: "-DSPLIT_BASE=1"
       Extensions:    MultiParamTypeClasses, FunctionalDependencies, CPP, ForeignFunctionInterface, ScopedTypeVariables, GeneralizedNewtypeDeriving, FlexibleContexts, TypeSynonymInstances, FlexibleInstances
     else
-      Build-Depends: base < 3.0, regex-base >=0.93 && <0.94
+      Build-Depends: base < 3.0, regex-base >=0.93 && <0.95
       Extensions:    MultiParamTypeClasses, FunctionalDependencies, CPP
+  if impl(ghc < 8)
+    Build-Depends: fail
   Exposed-Modules:        Text.Regex.PCRE
                           Text.Regex.PCRE.Wrap
                           Text.Regex.PCRE.String


### PR DESCRIPTION
I've compiled this locally with GHC-7.0.4 up to and including GHC-8.8.1. `regex-base-0.93` is also still supported.