### PR TITLE
Fix builds with GHC<8

### DIFF
--- a/regex-pcre-builtin.cabal
+++ b/regex-pcre-builtin.cabal
@@ -1,5 +1,5 @@
 Name:                   regex-pcre-builtin
-Version:                0.95.1.0.8.43
+Version:                0.95.1.1.8.43
 Cabal-Version:          >=1.10
 stability:              Seems to work, passes a few tests
 build-type:             Simple

--- a/src/Text/Regex/PCRE/Wrap.hsc
+++ b/src/Text/Regex/PCRE/Wrap.hsc
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wno-unused-do-bind #-}
+{-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 -- The exported symbols are the same whether HAVE_PCRE_H is defined,
 -- but when if it is not defined then 'getVersion == Nothing' and all
 -- other exported values will call error or fail.


### PR DESCRIPTION
Terribly sorry about this, but I messed up a bit in my previous PR. Long story short, I used a compiler pragma to suppress some warnings (unused do bind) that only appeared in GHC 8. I did test the PR, but as luck would have it, I neglected to test on any GHC 7.x compilers. So... yeah.

This PR tries to amend that. This time, I did test with GHC 7.

Bumping the version to 0.95.1.1.8.43.

Sorry again.