### PR TITLE
Support base-4.14.0.0

### DIFF
--- a/regex-pcre-builtin.cabal
+++ b/regex-pcre-builtin.cabal
@@ -55,7 +55,7 @@ library
       FlexibleInstances
 
   build-depends: regex-base == 0.94.*
-               , base       >= 4.3 && < 4.14
+               , base       >= 4.3 && < 4.15
                , containers >= 0.4 && < 0.7
                , bytestring >= 0.9 && < 0.11
                , array      >= 0.3 && < 0.6


### PR DESCRIPTION
Cabal-3.2.0.0 was throwing "cabal: Missing dependency on a foreign library: * Missing (or bad) header file: pcre". Which seemed rubbish as the header files are installed. 

The current GHC (8.10.1) comes packaged with base-4.14.0.0 by default (even though it hasn't been uploaded to hackage yet?). 

Bumping up the 'base' package resolved the error and it cabal-installed on my computer fine.  