### PR TITLE
fix broken Text regexes

### DIFF
--- a/src/Text/Regex/PCRE/Text.hs
+++ b/src/Text/Regex/PCRE/Text.hs
@@ -51,6 +51,8 @@ module Text.Regex.PCRE.Text
 
 import           Data.Array(Array,listArray)
 import           Data.Char(ord)
+import           Control.Monad.Fail (fail)
+import           Prelude hiding (fail)
 import qualified Data.ByteString              as B
 import qualified Data.ByteString.Unsafe       as B
 import qualified Data.Text                    as T

--- a/src/Text/Regex/PCRE/Text.hs
+++ b/src/Text/Regex/PCRE/Text.hs
@@ -50,6 +50,7 @@ module Text.Regex.PCRE.Text
   ) where
 
 import           Data.Array(Array,listArray)
+import           Data.Char(ord)
 import qualified Data.ByteString              as B
 import qualified Data.ByteString.Unsafe       as B
 import qualified Data.Text                    as T
@@ -154,7 +155,9 @@ unwrap x = case x of
 
 {-# INLINE asCString #-}
 asCString :: T.Text -> (CString->IO a) -> IO a
-asCString = B.unsafeUseAsCString . T.encodeUtf8
+asCString t
+  | T.null t || (ord (T.last t) /= 0) = B.useAsCString $ T.encodeUtf8 t
+  | otherwise = B.unsafeUseAsCString $ T.encodeUtf8 t
 
 {-# INLINE asCStringLen #-}
 asCStringLen :: T.Text -> (CStringLen->IO a) -> IO a


### PR DESCRIPTION
asCString for Text regexes doesn't check for null-termination, causing the compiled regex to be corrupted.  This PR checks for null termination and adds one if the string isn't null terminated.