### PR TITLE
Version bump to reflect pcre version and include #15

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 See also http://pvp.haskell.org/faq
 
+## 0.95.1.3.8.43
+- Version bump to reflect pcre version (8.43) and to have Hackage upgrade from 0.95.1.2.8.43 which does not include #15
+
 ## 0.95.1.1.8.44
 - Fix: `asCString` for `Text` regexes doesn't check for null-termination, causing the compiled regex to be corrupted. (@kuribas)
 

--- a/regex-pcre-builtin.cabal
+++ b/regex-pcre-builtin.cabal
@@ -1,5 +1,5 @@
 Name:                   regex-pcre-builtin
-Version:                0.95.1.1.8.44
+Version:                0.95.1.3.8.43
 Cabal-Version:          >=1.10
 stability:              Seems to work, passes a few tests
 build-type:             Simple


### PR DESCRIPTION
0.95.1.1.8.44 is current latest master and it includes the very important fix in #15.

But on Hackage the latest version is 0.95.1.2.8.43, which seems to be almost the same as 0.95.1.1.8.43 and definitely does not include #15:

```
$ diff -ur regex-pcre-builtin-0.95.1.1.8.43 regex-pcre-builtin-0.95.1.2.8.43
diff -ur regex-pcre-builtin-0.95.1.1.8.43/regex-pcre-builtin.cabal regex-pcre-builtin-0.95.1.2.8.43/regex-pcre-builtin.cabal
--- regex-pcre-builtin-0.95.1.1.8.43/regex-pcre-builtin.cabal   2001-09-09 03:46:40.000000000 +0200
+++ regex-pcre-builtin-0.95.1.2.8.43/regex-pcre-builtin.cabal   2020-04-16 07:08:54.000000000 +0200
@@ -1,5 +1,5 @@
 Name:                   regex-pcre-builtin
-Version:                0.95.1.1.8.43
+Version:                0.95.1.2.8.43
 Cabal-Version:          >=1.10
 stability:              Seems to work, passes a few tests
 build-type:             Simple
@@ -55,7 +55,7 @@
       FlexibleInstances

   build-depends: regex-base == 0.94.*
-               , base       >= 4.3 && < 4.14
+               , base       >= 4.3 && < 4.15
                , containers >= 0.4 && < 0.7
                , bytestring >= 0.9 && < 0.11
                , array      >= 0.3 && < 0.6
```

This PR just bumps the version to 0.95.1.3.8.43 so that:
* the last two numbers reflect the libpcre version again
* releasing to Hackage will make the latest version there include #15